### PR TITLE
next version preparation: hero: add a Container.Inject method to inje…

### DIFF
--- a/hero/binding.go
+++ b/hero/binding.go
@@ -125,13 +125,15 @@ func getBindingsFor(inputs []reflect.Type, deps []*Dependency, paramsCount int) 
 	// Therefore, count the inputs that can be path parameters first.
 	shouldBindParams := make(map[int]struct{})
 	totalParamsExpected := 0
-	for i, in := range inputs {
-		if _, canBePathParameter := context.ParamResolvers[in]; !canBePathParameter {
-			continue
-		}
-		shouldBindParams[i] = struct{}{}
+	if paramsCount != -1 {
+		for i, in := range inputs {
+			if _, canBePathParameter := context.ParamResolvers[in]; !canBePathParameter {
+				continue
+			}
+			shouldBindParams[i] = struct{}{}
 
-		totalParamsExpected++
+			totalParamsExpected++
+		}
 	}
 
 	startParamIndex := paramsCount - totalParamsExpected

--- a/hero/reflect.go
+++ b/hero/reflect.go
@@ -7,12 +7,21 @@ import (
 )
 
 func valueOf(v interface{}) reflect.Value {
-	if v, ok := v.(reflect.Value); ok {
+	if val, ok := v.(reflect.Value); ok {
 		// check if it's already a reflect.Value.
-		return v
+		return val
 	}
 
 	return reflect.ValueOf(v)
+}
+
+func typeOf(typ interface{}) reflect.Type {
+	if v, ok := typ.(reflect.Type); ok {
+		// check if it's already a reflect.Type.
+		return v
+	}
+
+	return reflect.TypeOf(typ)
 }
 
 // indirectType returns the value of a pointer-type "typ".
@@ -82,9 +91,8 @@ func equalTypes(binding reflect.Type, input reflect.Type) bool {
 	// if accepts an interface, check if the given "got" type does
 	// implement this "expected" user handler's input argument.
 	if input.Kind() == reflect.Interface {
-		// fmt.Printf("expected interface = %s and got to set on the arg is: %s\n", expected.String(), got.String())
-		// return got.Implements(expected)
-		// return expected.AssignableTo(got)
+		// fmt.Printf("expected interface = %s and got to set on the arg is: %s\n", binding.String(), input.String())
+		// return input.Implements(binding)
 		return binding.AssignableTo(input)
 	}
 


### PR DESCRIPTION
…ct values outside of HTTP lifecycle, e.g. a database may be used by other services outside of Iris, the hero container (and API's Builder.GetContainer()) should provide it.

# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/kataras/iris/blob/master/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.